### PR TITLE
added build config for linux-ARM target on linux-ARM

### DIFF
--- a/native-linux-arm/pom.xml
+++ b/native-linux-arm/pom.xml
@@ -14,6 +14,51 @@
     </parent>
     <profiles>
         <profile>
+            <id>build-host-linux-arm</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>arm</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <javahClassNames>
+                                <javahClassName>gnu.io.RXTXPort</javahClassName>
+                            </javahClassNames>
+                            <javahOS>linux</javahOS>
+                            <compilerProvider>generic-classic</compilerProvider>
+                            <compilerStartOptions>
+                                <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
+                                <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
+                                <compilerStartOption>-DHAVE_SYS_FCNTL_H</compilerStartOption>
+                                <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
+                                <compilerStartOption>-shared</compilerStartOption>
+                                <compilerStartOption>-fPIC</compilerStartOption>
+                            </compilerStartOptions>
+                            <linkerStartOptions>
+                                <linkerStartOption>-shared</linkerStartOption>
+                                <linkerStartOption>-fPIC</linkerStartOption>
+                            </linkerStartOptions>
+                            <sources>
+                                <source>
+                                    <directory>${project.build.directory}/extracted-c</directory>
+                                    <fileNames>
+                                        <fileName>SerialImp.c</fileName>
+                                    </fileNames>
+                                </source>
+                            </sources>
+                        </configuration>
+                    </plugin>  
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>build-host-linux-x86</id>
             <activation>
                 <os>

--- a/native-linux-arm/pom.xml
+++ b/native-linux-arm/pom.xml
@@ -21,35 +21,79 @@
                     <arch>i386</arch>
                 </os>
             </activation>
-            <properties>
-                <rxtx.os.javah>linux</rxtx.os.javah>
-            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <javahClassNames>
+                                <javahClassName>gnu.io.RXTXPort</javahClassName>
+                            </javahClassNames>
+                            <javahOS>linux</javahOS>
+                            <compilerProvider>generic-classic</compilerProvider>
+                            <compilerExecutable>${project.build.directory}/arm-linux</compilerExecutable>
+                            <linkerExecutable>${project.build.directory}/arm-linux</linkerExecutable>
+                            <compilerStartOptions>
+                                <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
+                                <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
+                                <compilerStartOption>-DHAVE_SYS_FCNTL_H</compilerStartOption>
+                                <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
+                                <compilerStartOption>-shared</compilerStartOption>
+                                <compilerStartOption>-fPIC</compilerStartOption>
+                            </compilerStartOptions>
+                            <linkerStartOptions>
+                                <linkerStartOption>-shared</linkerStartOption>
+                                <linkerStartOption>-fPIC</linkerStartOption>
+                            </linkerStartOptions>
+                            <sources>
+                                <source>
+                                    <directory>${project.build.directory}/extracted-c</directory>
+                                    <fileNames>
+                                        <fileName>SerialImp.c</fileName>
+                                    </fileNames>
+                                </source>
+                            </sources>
+                        </configuration>
+                    </plugin>  
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>failOnUnsupportedPlatforms</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build> 
+                <plugins> 
+                    <plugin> 
+                        <groupId>org.apache.maven.plugins</groupId> 
+                        <artifactId>maven-enforcer-plugin</artifactId> 
+                        <version>1.1.1</version> 
+                        <executions> 
+                            <execution> 
+                                <id>enforce</id> 
+                                <goals> 
+                                    <goal>enforce</goal> 
+                                </goals>
+                                <configuration> 
+                                    <rules> 
+                                        <AlwaysFail>
+                                            <message>Sorry, the rxtx binary for the unix/arm platform can be build on the following systems only: * unix/x86 If you know about a working cross-platform build procedure for other platforms, please bring this up at the rxtx mailing list.</message>
+                                        </AlwaysFail>
+                                    </rules> 
+                                    <fail>true</fail> 
+                                </configuration> 
+                            </execution> 
+                        </executions> 
+                    </plugin> 
+                </plugins> 
+            </build>
         </profile>
     </profiles>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-os</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireOS>
-                                    <family>unix</family>
-                                    <arch>i386</arch>
-                                    <message>Sorry, the rxtx binary for the unix/arm platform can be build on the following systems only: * unix/x86 If you know about a working cross-platform build procedure for other platforms, please bring this up at the rxtx mailing list.</message>
-                                </requireOS>
-                            </rules>  
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -106,40 +150,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>native-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <javahClassNames>
-                        <javahClassName>gnu.io.RXTXPort</javahClassName>
-                    </javahClassNames>
-                    <javahOS>${rxtx.os.javah}</javahOS>
-                    <compilerProvider>generic-classic</compilerProvider>
-                    <compilerExecutable>${project.build.directory}/arm-linux</compilerExecutable>
-                    <linkerExecutable>${project.build.directory}/arm-linux</linkerExecutable>
-                    <compilerStartOptions>
-                        <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
-                        <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
-                        <compilerStartOption>-DHAVE_SYS_FCNTL_H</compilerStartOption>
-                        <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
-                        <compilerStartOption>-shared</compilerStartOption>
-                        <compilerStartOption>-fPIC</compilerStartOption>
-                    </compilerStartOptions>
-                    <linkerStartOptions>
-                        <linkerStartOption>-shared</linkerStartOption>
-                        <linkerStartOption>-fPIC</linkerStartOption>
-                    </linkerStartOptions>
-                    <sources>
-                        <source>
-                            <directory>${project.build.directory}/extracted-c</directory>
-                            <fileNames>
-                                <fileName>SerialImp.c</fileName>
-                            </fileNames>
-                        </source>
-                    </sources>
-                </configuration>
-            </plugin>        
         </plugins>
     </build>
     <dependencies>      

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,13 @@
         </profile>
         <profile>
             <id>with-linux-arm</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <name>linux</name>
+                    <arch>arm</arch>
+                </os>
+            </activation>
             <modules>
                 <module>native-linux-arm</module>
             </modules>


### PR DESCRIPTION
Enables an ARM based linux machine to build itself a rxtx binary. This was tested on a Raspberry Pi model B using a hard float debian "Wheezy" and "Java SE 8 (with JavaFX) Developer Preview for ARM".
