### PR TITLE
fixes maven build of windows native libraries on linux with mingw

### DIFF
--- a/cross-toolchain-wrapper/src/assemble/src.xml
+++ b/cross-toolchain-wrapper/src/assemble/src.xml
@@ -10,6 +10,7 @@
         <fileSet>
             <directory>${project.basedir}/src/main/bash</directory>
             <outputDirectory/>
+            <fileMode>0755</fileMode>
         </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
Hi,

this little patch fixes a problem with insufficient permissions of the wrapper-toolchain when building windows native libraries from linux. The maven build fails to execute the mingw32/64 shell scripts due to the missing execute flag. The patch configures the maven-assembly-plugin to set the flags after extracting the scripts.

Cheers,
Jan
