### PR TITLE
Released exclusivity on port

### DIFF
--- a/rxtxSerial-native/src/main/c/SerialImp.c
+++ b/rxtxSerial-native/src/main/c/SerialImp.c
@@ -780,6 +780,13 @@ JNIEXPORT void JNICALL RXTXPort(nativeClose)( JNIEnv *env,
 		report("nativeClose: discarding remaining data (tcflush)\n");
 		/* discard any incoming+outgoing data not yet read/sent */
 		tcflush(fd, TCIOFLUSH);
+#ifdef OPEN_EXCL
+		/*
+		   If the port was opened exclusively, release the exclusive access to allow
+		   re-connects
+		 */
+		ioctl(fd, TIOCNXCL);
+#endif /* OPEN_EXCL */
  		do {
 			report("nativeClose:  calling close\n");
 			result=CLOSE (fd);


### PR DESCRIPTION
Signaled TIOCNXCL when port was opened with TIOCEXCL to allow reconnections later. This was particularly a problem when attempting to reconnect to a virtual serial port through socat on OSX 10.9.5.
