### PR TITLE
Improve error and lock handling  while opening the port

### DIFF
--- a/rxtx-api/src/main/java/gnu/io/CommPortIdentifier.java
+++ b/rxtx-api/src/main/java/gnu/io/CommPortIdentifier.java
@@ -59,6 +59,7 @@ package gnu.io;
 
 import gnu.io.spi.CommDriver;
 import java.io.FileDescriptor;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Vector;
 import java.util.Enumeration;
@@ -376,7 +377,6 @@ public final class CommPortIdentifier extends Object {
         throw new UnsupportedCommOperationException();
     }
 
-    private native String native_psmisc_report_owner(String PortName);
     private boolean HideOwnerEvents;
 
     /**
@@ -401,7 +401,7 @@ public final class CommPortIdentifier extends Object {
     // can reach applications outside of this virtual machine, probably not
     // not written in java? I can't see where this request is done.
     public CommPort open(String owner, int timeLimit)
-            throws gnu.io.PortInUseException {
+            throws gnu.io.PortInUseException, IOException {
         boolean isAvailable;
         synchronized (this) {
             isAvailable = this.available;
@@ -445,14 +445,7 @@ public final class CommPortIdentifier extends Object {
                 fireOwnershipEvent(CommPortOwnershipListener.PORT_OWNED);
                 return commPort;
             } else {
-                String errMsg;
-                try {
-                    errMsg = native_psmisc_report_owner(portName);
-                } catch (Throwable t) {
-                    errMsg = "Port " + portName
-                            + " already owned... unable to open.";
-                }
-                throw new gnu.io.PortInUseException(errMsg);
+                throw new gnu.io.PortInUseException();
             }
         } finally {
             if (commPort == null) {

--- a/rxtx-api/src/main/java/gnu/io/spi/CommDriver.java
+++ b/rxtx-api/src/main/java/gnu/io/spi/CommDriver.java
@@ -59,6 +59,9 @@ package gnu.io.spi;
 
 import gnu.io.CommPort;
 import gnu.io.DriverContext;
+import gnu.io.PortInUseException;
+
+import java.io.IOException;
 
 /**
  * The
@@ -96,7 +99,7 @@ public interface CommDriver {
      * describing the type of the port
      * @return the <code>CommPort</code> instance or <code>null</code>
      */
-    CommPort getCommPort(String portName, int portType);
+    CommPort getCommPort(String portName, int portType) throws PortInUseException, IOException;
 
     /**
      * Initializes this driver. This method is called by rxtx once in a virtual

--- a/rxtxSerial-java/src/main/java/gnu/io/impl/serial/RXTXCommDriver.java
+++ b/rxtxSerial-java/src/main/java/gnu/io/impl/serial/RXTXCommDriver.java
@@ -712,12 +712,14 @@ public final class RXTXCommDriver implements CommDriver {
     /**
      * @param portName The name of the port the OS recognizes
      * @param portType CommPortIdentifier.PORT_SERIAL or PORT_PARALLEL
+     * @throws PortInUseException when port is already in use by another application
+     * @throws IOException when port cannot be opened for another reason
      * @return CommPort getCommPort() will be called by CommPortIdentifier from
      * its openPort() method. PortName is a string that was registered earlier
      * using the CommPortIdentifier.addPortName() method. getCommPort() returns
      * an object that extends either SerialPort or ParallelPort.
      */
-    public CommPort getCommPort(String portName, int portType) {
+    public CommPort getCommPort(String portName, int portType) throws IOException, PortInUseException {
         if (portType != CommPortIdentifier.PORT_SERIAL) {
             LOGGER.log(Level.WARNING,
                     "unknown port type {0} passed, "
@@ -734,7 +736,10 @@ public final class RXTXCommDriver implements CommDriver {
         } catch (PortInUseException e) {
             LOGGER.log(Level.INFO, "Port {0} in use by another application",
                     portName);
+            throw e;
+        } catch (IOException e) {
+            LOGGER.log(Level.INFO, "Port {0} open failed!", portName);
+            throw e;
         }
-        return null;
     }
 }

--- a/rxtxSerial-java/src/main/java/gnu/io/impl/serial/RXTXPort.java
+++ b/rxtxSerial-java/src/main/java/gnu/io/impl/serial/RXTXPort.java
@@ -177,7 +177,7 @@ final class RXTXPort extends SerialPort {
      * @throws PortInUseException
      * @see gnu.io.SerialPort
      */
-    public RXTXPort(DriverContext context, String name) throws PortInUseException {
+    public RXTXPort(DriverContext context, String name) throws PortInUseException, IOException {
         super(name);
         this.context = context;
         /*
@@ -205,7 +205,7 @@ final class RXTXPort extends SerialPort {
     }
 
     private synchronized native int open(String name)
-            throws PortInUseException;
+            throws PortInUseException, IOException;
 
     public OutputStream getOutputStream() {
         return out;

--- a/rxtxSerial-native/src/main/c/SerialImp.c
+++ b/rxtxSerial-native/src/main/c/SerialImp.c
@@ -718,13 +718,21 @@ JNIEXPORT jint JNICALL RXTXPort(open)(
        }
 #endif /* OPEN_EXCL */
 
-	if( configure_port( fd ) ) goto fail;
+	if( configure_port( fd ) ) goto fail_unlock;
 	(*env)->ReleaseStringUTFChars( env, jstr, filename );
 	sprintf( message, "open: fd returned is %i\n", fd );
 	report( message );
 	LEAVE( "RXTXPort:open" );
 	report_time_end( );
 	return (jint)fd;
+
+fail_unlock:
+        UNLOCK( filename, pid );
+	(*env)->ReleaseStringUTFChars( env, jstr, filename );
+	LEAVE( "RXTXPort:open" );
+	throw_java_exception( env, IO_EXCEPTION, "open",
+		strerror( errno ) );
+	return -1;
 
 fail:
 	(*env)->ReleaseStringUTFChars( env, jstr, filename );


### PR DESCRIPTION
open call on CommPort can now throw an IOException as well, to differentiate between situation when port is already used and locked (in that case PortInUseException is thrown) and situations when configure_port(fd) fails (in that case, IOException is thrown).
Removed call to now not exported JNI call native_psmisc_report_owner.
Fixed issue where failed configure_port(fd) call will leave port in locked state.