### PR TITLE
Add header options for current Mac JDKs

### DIFF
--- a/librxtxSerial-osx-x86_64/pom.xml
+++ b/librxtxSerial-osx-x86_64/pom.xml
@@ -101,6 +101,8 @@
                         <compilerStartOption>-shared</compilerStartOption>
                         <compilerStartOption>-fPIC</compilerStartOption>
                         <compilerStartOption>-I/System/Library/Frameworks/JavaVM.framework/Headers</compilerStartOption>
+                        <compilerStartOption>-I${JAVA_HOME}/include/darwin/</compilerStartOption>
+                        <compilerStartOption>-I${JAVA_HOME}/include/</compilerStartOption>
                     </compilerStartOptions>
                     <linkerStartOptions>
                         <linkerStartOption>-shared</linkerStartOption>


### PR DESCRIPTION
Two -I options were missing