### PR TITLE
Feature/jni without javah

### DIFF
--- a/rxtx-api/pom.xml
+++ b/rxtx-api/pom.xml
@@ -21,8 +21,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>7</source>
+                    <target>7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>      

--- a/rxtxSerial-java/pom.xml
+++ b/rxtxSerial-java/pom.xml
@@ -21,8 +21,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>7</source>
+                    <target>7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/rxtxSerial-java/pom.xml
+++ b/rxtxSerial-java/pom.xml
@@ -20,11 +20,33 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
+                    <compilerArgs>
+                        <arg>-h</arg>
+                        <arg>${project.build.directory}/headers</arg>
+                    </compilerArgs>
                     <source>7</source>
                     <target>7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jni-header-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assemble/src.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/rxtxSerial-java/src/assemble/src.xml
+++ b/rxtxSerial-java/src/assemble/src.xml
@@ -1,0 +1,15 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>jni-headers</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/headers</directory>
+            <outputDirectory/>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/rxtxSerial-linux-armel/pom.xml
+++ b/rxtxSerial-linux-armel/pom.xml
@@ -22,9 +22,6 @@
                     <arch>i386</arch>
                 </os>
             </activation>
-            <properties>
-                <rxtx.os.javah>linux</rxtx.os.javah>
-            </properties>
         </profile>
         <profile>
             <id>build-host-linux-x86_64</id>
@@ -35,9 +32,6 @@
                     <arch>amd64</arch>
                 </os>
             </activation>
-            <properties>
-                <rxtx.os.javah>linux</rxtx.os.javah>
-            </properties>
         </profile>
         <profile>
             <id>failOnUnsupportedPlatforms</id>
@@ -107,6 +101,27 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>unpack-jni-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>gnu.io.rxtx</groupId>
+                                    <artifactId>rxtxSerial-java</artifactId>
+                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <type>zip</type>
+                                    <classifier>jni-headers</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jni-headers</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>unpack-cross-toolchain-wrapper</id>
                         <phase>process-sources</phase>
                         <goals>
@@ -134,10 +149,6 @@
                 <artifactId>native-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <javahClassNames>
-                        <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                    </javahClassNames>
-                    <javahOS>${rxtx.os.javah}</javahOS>
                     <compilerProvider>generic-classic</compilerProvider>
                     <compilerExecutable>${project.build.directory}/armel-linux</compilerExecutable>
                     <linkerExecutable>${project.build.directory}/armel-linux</linkerExecutable>
@@ -148,6 +159,9 @@
                         <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
                         <compilerStartOption>-shared</compilerStartOption>
                         <compilerStartOption>-fPIC</compilerStartOption>
+                        <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                        <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                        <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
                     </compilerStartOptions>
                     <linkerStartOptions>
                         <linkerStartOption>-shared</linkerStartOption>

--- a/rxtxSerial-linux-armhf/pom.xml
+++ b/rxtxSerial-linux-armhf/pom.xml
@@ -22,9 +22,6 @@
                     <arch>i386</arch>
                 </os>
             </activation>
-            <properties>
-                <rxtx.os.javah>linux</rxtx.os.javah>
-            </properties>
         </profile>
         <profile>
             <id>build-host-linux-x86_64</id>
@@ -35,9 +32,6 @@
                     <arch>amd64</arch>
                 </os>
             </activation>
-            <properties>
-                <rxtx.os.javah>linux</rxtx.os.javah>
-            </properties>
         </profile>
         <profile>
             <id>failOnUnsupportedPlatforms</id>
@@ -107,6 +101,27 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>unpack-jni-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>gnu.io.rxtx</groupId>
+                                    <artifactId>rxtxSerial-java</artifactId>
+                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <type>zip</type>
+                                    <classifier>jni-headers</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jni-headers</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>unpack-cross-toolchain-wrapper</id>
                         <phase>process-sources</phase>
                         <goals>
@@ -134,10 +149,6 @@
                 <artifactId>native-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <javahClassNames>
-                        <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                    </javahClassNames>
-                    <javahOS>${rxtx.os.javah}</javahOS>
                     <compilerProvider>generic-classic</compilerProvider>
                     <compilerExecutable>${project.build.directory}/armhf-linux</compilerExecutable>
                     <linkerExecutable>${project.build.directory}/armhf-linux</linkerExecutable>
@@ -148,6 +159,9 @@
                         <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
                         <compilerStartOption>-shared</compilerStartOption>
                         <compilerStartOption>-fPIC</compilerStartOption>
+                        <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                        <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                        <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
                     </compilerStartOptions>
                     <linkerStartOptions>
                         <linkerStartOption>-shared</linkerStartOption>

--- a/rxtxSerial-linux-x86/pom.xml
+++ b/rxtxSerial-linux-x86/pom.xml
@@ -29,10 +29,6 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerStartOptions>
                                 <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
                                 <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
@@ -40,6 +36,9 @@
                                 <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
                                 <compilerStartOption>-shared</compilerStartOption>
                                 <compilerStartOption>-fPIC</compilerStartOption>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
                             </compilerStartOptions>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -73,10 +72,6 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerStartOptions>
                                 <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
                                 <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
@@ -85,6 +80,9 @@
                                 <compilerStartOption>-m32</compilerStartOption>
                                 <compilerStartOption>-shared</compilerStartOption>
                                 <compilerStartOption>-fPIC</compilerStartOption>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
                             </compilerStartOptions>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -164,6 +162,27 @@
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/extracted-c</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-jni-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>gnu.io.rxtx</groupId>
+                                    <artifactId>rxtxSerial-java</artifactId>
+                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <type>zip</type>
+                                    <classifier>jni-headers</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jni-headers</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                             <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>

--- a/rxtxSerial-linux-x86_64/pom.xml
+++ b/rxtxSerial-linux-x86_64/pom.xml
@@ -29,10 +29,6 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerStartOptions>
                                 <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
                                 <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
@@ -40,6 +36,9 @@
                                 <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
                                 <compilerStartOption>-shared</compilerStartOption>
                                 <compilerStartOption>-fPIC</compilerStartOption>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
                             </compilerStartOptions>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -73,10 +72,6 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerStartOptions>
                                 <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
                                 <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
@@ -85,6 +80,9 @@
                                 <compilerStartOption>-m64</compilerStartOption>
                                 <compilerStartOption>-shared</compilerStartOption>
                                 <compilerStartOption>-fPIC</compilerStartOption>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
                             </compilerStartOptions>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -164,6 +162,27 @@
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/extracted-c</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-jni-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>gnu.io.rxtx</groupId>
+                                    <artifactId>rxtxSerial-java</artifactId>
+                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <type>zip</type>
+                                    <classifier>jni-headers</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jni-headers</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                             <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>

--- a/rxtxSerial-osx-x86_64/pom.xml
+++ b/rxtxSerial-osx-x86_64/pom.xml
@@ -28,10 +28,6 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>mac</javahOS>
                             <compilerStartOptions>
                                 <compilerStartOption>-DHAVE_TERMIOS_H</compilerStartOption>
                                 <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
@@ -39,6 +35,7 @@
                                 <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
                                 <compilerStartOption>-shared</compilerStartOption>
                                 <compilerStartOption>-fPIC</compilerStartOption>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
                                 <compilerStartOption>-I/System/Library/Frameworks/JavaVM.framework/Headers</compilerStartOption>
                             </compilerStartOptions>
                             <linkerStartOptions>
@@ -75,10 +72,6 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>mac</javahOS>
                             <compilerProvider>generic</compilerProvider>
                             <compilerExecutable>${project.build.directory}/apple64</compilerExecutable>
                             <linkerExecutable>${project.build.directory}/apple64</linkerExecutable>
@@ -89,6 +82,7 @@
                                 <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
                                 <compilerStartOption>-shared</compilerStartOption>
                                 <compilerStartOption>-fPIC</compilerStartOption>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
                                 <compilerStartOption>-I/System/Library/Frameworks/JavaVM.framework/Headers</compilerStartOption>
                                 <compilerStartOption>-arch x86_64</compilerStartOption>
                             </compilerStartOptions>
@@ -171,6 +165,27 @@
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/extracted-c</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-jni-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>gnu.io.rxtx</groupId>
+                                    <artifactId>rxtxSerial-java</artifactId>
+                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <type>zip</type>
+                                    <classifier>jni-headers</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jni-headers</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                             <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>

--- a/rxtxSerial-windows-x86/pom.xml
+++ b/rxtxSerial-windows-x86/pom.xml
@@ -28,12 +28,13 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerProvider>generic-classic</compilerProvider>
                             <compilerExecutable>${project.build.directory}/mingw32</compilerExecutable>
+                            <compilerStartOptions>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
+                            </compilerStartOptions>
                             <linkerExecutable>${project.build.directory}/mingw32</linkerExecutable>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -67,12 +68,13 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerProvider>generic-classic</compilerProvider>
                             <compilerExecutable>${project.build.directory}/mingw32</compilerExecutable>
+                            <compilerStartOptions>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
+                            </compilerStartOptions>
                             <linkerExecutable>${project.build.directory}/mingw32</linkerExecutable>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -152,6 +154,27 @@
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/extracted-c</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-jni-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>gnu.io.rxtx</groupId>
+                                    <artifactId>rxtxSerial-java</artifactId>
+                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <type>zip</type>
+                                    <classifier>jni-headers</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jni-headers</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                             <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>

--- a/rxtxSerial-windows-x86_64/pom.xml
+++ b/rxtxSerial-windows-x86_64/pom.xml
@@ -28,12 +28,13 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerProvider>generic-classic</compilerProvider>
                             <compilerExecutable>${project.build.directory}/mingw64</compilerExecutable>
+                            <compilerStartOptions>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
+                            </compilerStartOptions>
                             <linkerExecutable>${project.build.directory}/mingw64</linkerExecutable>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -67,12 +68,13 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <javahClassNames>
-                                <javahClassName>gnu.io.impl.serial.RXTXPort</javahClassName>
-                            </javahClassNames>
-                            <javahOS>linux</javahOS>
                             <compilerProvider>generic-classic</compilerProvider>
                             <compilerExecutable>${project.build.directory}/mingw64</compilerExecutable>
+                            <compilerStartOptions>
+                                <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include</compilerStartOption>
+                                <compilerStartOption>-I${env.JAVA_HOME}/include/linux</compilerStartOption>
+                            </compilerStartOptions>
                             <linkerExecutable>${project.build.directory}/mingw64</linkerExecutable>
                             <linkerStartOptions>
                                 <linkerStartOption>-shared</linkerStartOption>
@@ -158,6 +160,27 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>unpack-jni-headers</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>gnu.io.rxtx</groupId>
+                                    <artifactId>rxtxSerial-java</artifactId>
+                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <type>zip</type>
+                                    <classifier>jni-headers</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jni-headers</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>unpack-cross-toolchain-wrapper</id>
                         <phase>process-sources</phase>
                         <goals>
@@ -191,6 +214,13 @@
         <dependency>
             <groupId>gnu.io.rxtx</groupId>
             <artifactId>rxtxSerial-native</artifactId>
+            <scope>compile</scope>
+            <classifier>sources</classifier>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>gnu.io.rxtx</groupId>
+            <artifactId>cross-toolchain-wrapper</artifactId>
             <scope>compile</scope>
             <classifier>sources</classifier>
             <type>zip</type>


### PR DESCRIPTION
Builds of rxtx have not been possible with recent JDKs, because we required the javah tool to be available, which is no longer part of JDKs. This feature migrates to javac -h in order to create JNI headers.