### PR TITLE
Feature/add GitHub workflow

### DIFF
--- a/.github/workflows/rxtx-distribution.yml
+++ b/.github/workflows/rxtx-distribution.yml
@@ -1,0 +1,63 @@
+# This workflow will build a distribution bundle containing everything needed to run rxtx on supported platforms.
+
+name: build rxtx-distribution
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+jobs:
+  build-osx-binaries:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Build with Maven
+      run: mvn --batch-mode -Pwith-osx-x86_64 package --file pom.xml
+    - name: upload rxtxSerial binaries built on osx
+      uses: actions/upload-artifact@v2
+      with:
+        name: rxtxSerial-binaries-built-on-osx
+        path: rxtxSerial-osx-*/target/librxtxSerial-osx-*.jnilib
+        if-no-files-found: error
+
+  main-build:
+    needs: build-osx-binaries
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare installation of 32bit packages
+      run: sudo dpkg --add-architecture i386 && sudo apt update
+    - name: Install cross toolchains and libraries
+      run: sudo apt install libc6-dev-i386 linux-libc-dev:i386 gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - uses: actions/download-artifact@v2
+      with:
+        name: rxtxSerial-binaries-built-on-osx
+    - name: install osx native library
+      run: cd rxtxSerial-osx-x86_64 && mvn --batch-mode install:install-file -Dfile=target/librxtxSerial-osx-x86_64.jnilib -DgroupId=gnu.io.rxtx -DartifactId=librxtxSerial-osx-x86_64 -Dversion=2.2-stabilize-SNAPSHOT -Dpackaging=jnilib --file pom.xml
+    - name: Build for all other platforms
+      run: mvn --batch-mode -Pwith-linux-x86,with-linux-x86_64,with-linux-armel,with-linux-armhf,with-windows-x86,with-windows-x86_64 package install --file pom.xml
+    - name: Bundle rxtx Java and native libs
+      run: mvn --batch-mode -Dmake.release package --file pom.xml
+    - name: upload rxtx-distribution
+      uses: actions/upload-artifact@v2
+      with:
+        name: rxtx-distribution
+        path: |
+          rxtx-api/target/rxtx-api-*.jar
+          rxtxSerial/target/rxtxSerial-*.jar
+        if-no-files-found: error

--- a/pom.xml
+++ b/pom.xml
@@ -146,26 +146,12 @@
         </profile>
         <profile>
             <id>with-linux-x86</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                    <name>linux</name>
-                    <arch>i386</arch>
-                </os>
-            </activation>
             <modules>
                 <module>rxtxSerial-linux-x86</module>
             </modules>
         </profile>
         <profile>
             <id>with-linux-x86_64</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                    <name>linux</name>
-                    <arch>amd64</arch>
-                </os>
-            </activation>
             <modules>
                 <module>rxtxSerial-linux-x86_64</module>
             </modules>
@@ -196,12 +182,6 @@
         </profile>
         <profile>
             <id>with-osx-x86_64</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
             <modules>
                 <module>rxtxSerial-osx-x86_64</module>
             </modules>
@@ -218,37 +198,6 @@
                 <module>rxtxSerial</module>
                 <module>rxtxSerial-test</module>
             </modules>
-        </profile>
-        <profile>
-            <id>failOnUnsupportedPlatforms</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build> 
-                <plugins> 
-                    <plugin> 
-                        <groupId>org.apache.maven.plugins</groupId> 
-                        <artifactId>maven-enforcer-plugin</artifactId> 
-                        <version>1.1.1</version> 
-                        <executions> 
-                            <execution> 
-                                <id>enforce</id> 
-                                <goals> 
-                                    <goal>enforce</goal> 
-                                </goals>
-                                <configuration> 
-                                    <rules> 
-                                        <AlwaysFail>
-                                            <message>Your platform (=os/arch combination) is currently unsupported to build its own binary, however it might be possible to use other platforms to compile the necessary binary for you. This message does not necessarily mean that there is no way to run rxtx on your platform.</message>
-                                        </AlwaysFail>
-                                    </rules> 
-                                    <fail>true</fail> 
-                                </configuration> 
-                            </execution> 
-                        </executions> 
-                    </plugin> 
-                </plugins> 
-            </build>
         </profile>
     </profiles>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,38 @@
                 <module>rxtxSerial-test</module>
             </modules>
         </profile>
+        <profile>
+            <id>failNoBinarySelected</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build> 
+                <plugins> 
+                    <plugin> 
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <AlwaysFail>
+                                            <level>ERROR</level>
+                                            <message>No rxtx native target selected. Select target(s) by activating one or more of the following profiles: with-linux-x86, with-linux-x86_64, with-linux-armel, with-linux-armhf, with-windows-x86, with-windows-x86_64, with-osx-x86_64. Profiles can be activated using the maven option -P. Example: "mvn -Pwith-linux-x86,with-windows-x86 install". In order to successfully build the respective native targets, the proper (cross) compiler(s) must be installed. Refer to the rxtx documentation.</message>
+                                        </AlwaysFail>
+                                    </rules>
+                                    <fail>true</fail>
+                                    <failFast>true</failFast>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,15 @@
             </modules>
         </profile>
         <profile>
+            <id>run-release-assembly</id>
+            <activation>
+                <property>
+                    <name>make.release</name>
+                </property>
+            </activation>
+            <!-- The presence of this profile prevents activation of profile failNoBinarySelected during release bundle mode. -->
+         </profile>
+        <profile>
             <id>failNoBinarySelected</id>
             <activation>
                 <activeByDefault>true</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -255,13 +255,14 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.1.1</version>
+                    <version>3.0.0-M3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,50 +100,15 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <modules>
+        <module>rxtx-api</module>
+        <module>rxtxSerial-java</module>
+        <module>rxtxSerial-native</module>
+        <module>rxtxSerial-bin</module>
+        <module>rxtxSerial</module>
+        <module>rxtxSerial-test</module>
+    </modules>
     <profiles>
-        <profile>
-            <id>run-release-prepare</id>
-            <activation>
-                <property>
-                    <name>make.release</name>
-                    <value>prepare</value>
-                </property>
-            </activation>
-            <modules>
-                <module>cross-toolchain-wrapper</module>
-                <module>rxtx-api</module>
-                <module>rxtxSerial-java</module>
-                <module>rxtxSerial-native</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>run-release-assembly</id>
-            <activation>
-                <property>
-                    <name>make.release</name>
-                    <value>bundle</value>
-                </property>
-            </activation>
-            <modules>
-                <module>rxtxSerial-bin</module>
-                <module>rxtxSerial</module>
-                <module>rxtxSerial-test</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>run-development-build-head</id>
-            <activation>
-                <property>
-                    <name>!make.release</name>
-                </property>
-            </activation>
-            <modules>
-                <module>cross-toolchain-wrapper</module>
-                <module>rxtx-api</module>
-                <module>rxtxSerial-java</module>
-                <module>rxtxSerial-native</module>
-            </modules>
-        </profile>
         <profile>
             <id>with-linux-x86</id>
             <modules>
@@ -159,44 +124,36 @@
         <profile>
             <id>with-linux-armel</id>
             <modules>
+                <module>cross-toolchain-wrapper</module>
                 <module>rxtxSerial-linux-armel</module>
             </modules>
         </profile>
         <profile>
             <id>with-linux-armhf</id>
             <modules>
+                <module>cross-toolchain-wrapper</module>
                 <module>rxtxSerial-linux-armhf</module>
             </modules>
         </profile>
         <profile>
             <id>with-windows-x86</id>
             <modules>
+                <module>cross-toolchain-wrapper</module>
                 <module>rxtxSerial-windows-x86</module>
             </modules>
         </profile>
         <profile>
             <id>with-windows-x86_64</id>
             <modules>
+                <module>cross-toolchain-wrapper</module>
                 <module>rxtxSerial-windows-x86_64</module>
             </modules>
         </profile>
         <profile>
             <id>with-osx-x86_64</id>
             <modules>
+                <module>cross-toolchain-wrapper</module>
                 <module>rxtxSerial-osx-x86_64</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>run-development-build-tail</id>
-            <activation>
-                <property>
-                    <name>!make.release</name>
-                </property>
-            </activation>
-            <modules>
-                <module>rxtxSerial-bin</module>
-                <module>rxtxSerial</module>
-                <module>rxtxSerial-test</module>
             </modules>
         </profile>
         <profile>

--- a/rxtxSerial-bin/pom.xml
+++ b/rxtxSerial-bin/pom.xml
@@ -63,11 +63,6 @@
                 <property>
                     <name>make.release</name>
                 </property>
-                <os>
-                    <family>unix</family>
-                    <name>linux</name>
-                    <arch>i386</arch>
-                </os>
             </activation>
             <dependencies>
                 <dependency>
@@ -84,11 +79,6 @@
                 <property>
                     <name>make.release</name>
                 </property>
-                <os>
-                    <family>unix</family>
-                    <name>linux</name>
-                    <arch>amd64</arch>
-                </os>
             </activation>
             <dependencies>
                 <dependency>
@@ -159,10 +149,6 @@
                 <property>
                     <name>make.release</name>
                 </property>
-                <os>
-                    <family>mac</family>
-                    <arch>x86_64</arch>
-                </os>
             </activation>
             <dependencies>
                 <dependency>

--- a/rxtxSerial-bin/src/assemble/release.xml
+++ b/rxtxSerial-bin/src/assemble/release.xml
@@ -15,6 +15,7 @@
                 <include>gnu.io.rxtx:rxtxSerial-windows-x86_64</include>
                 <include>gnu.io.rxtx:librxtxSerial-osx-x86_64</include>
             </includes>
+            <useStrictFiltering>true</useStrictFiltering>
             <useProjectArtifact>false</useProjectArtifact>
             <outputDirectory>/gnu/io/impl/serial/</outputDirectory>
             <unpack>false</unpack>

--- a/rxtxSerial-native/src/main/c/SerialImp.c
+++ b/rxtxSerial-native/src/main/c/SerialImp.c
@@ -100,6 +100,9 @@
 #   include <sys/signal.h>
 #endif /* HAVE_SYS_SIGNAL_H */
 #include <sys/types.h>
+#ifdef HAVE_SYSMACROS_H
+#   include <sys/sysmacros.h>
+#endif /* HAVE_SYSMACROS_H */
 #ifdef HAVE_SYS_TIME_H
 #   include <sys/time.h>
 #endif /* HAVE_SYS_TIME_H */
@@ -5503,6 +5506,7 @@ int fhs_lock( const char *filename, pid_t pid )
 		rather than an exercise, we will handle them.
 
 ----------------------------------------------------------*/
+#if 0
 int uucp_lock( const char *filename, pid_t pid )
 {
 	char lockfilename[80], lockinfo[12], message[80];
@@ -5566,6 +5570,7 @@ int uucp_lock( const char *filename, pid_t pid )
 	close( fd );
 	return 0;
 }
+#endif
 
 /*----------------------------------------------------------
  check_lock_status
@@ -5648,6 +5653,7 @@ void fhs_unlock( const char *filename, int openpid )
    exceptions: none
    comments:   http://docs.freebsd.org/info/uucp/uucp.info.UUCP_Lock_Files.html
 ----------------------------------------------------------*/
+#if 0
 void uucp_unlock( const char *filename, int openpid )
 {
 	struct stat buf;
@@ -5686,7 +5692,7 @@ void uucp_unlock( const char *filename, int openpid )
 		report( message );
 	}
 }
-
+#endif
 /*----------------------------------------------------------
  check_lock_pid
 

--- a/rxtxSerial-osx-x86_64/pom.xml
+++ b/rxtxSerial-osx-x86_64/pom.xml
@@ -33,7 +33,7 @@
                                 <compilerStartOption>-DHAVE_STDINT_H</compilerStartOption>
                                 <compilerStartOption>-DHAVE_SYS_FCNTL_H</compilerStartOption>
                                 <compilerStartOption>-DHAVE_SYS_SIGNAL_H</compilerStartOption>
-                                <compilerStartOption>-shared</compilerStartOption>
+                                <compilerStartOption>-DHAVE_SYS_TIME_H</compilerStartOption>
                                 <compilerStartOption>-fPIC</compilerStartOption>
                                 <compilerStartOption>-I${project.build.directory}/jni-headers</compilerStartOption>
                                 <compilerStartOption>-I/System/Library/Frameworks/JavaVM.framework/Headers</compilerStartOption>


### PR DESCRIPTION
Provides a github actions workflow, which builds rxtx for all supported platforms and allows users to download binaries directly from github.

Only the binary for mac osx is built on a mac system. All other binaries and java parts of the library are built on a ubuntu 20.04 (via cross toolchains).