### PR TITLE
Feature/add GitHub release

### DIFF
--- a/.github/workflows/rxtx-distribution.yml
+++ b/.github/workflows/rxtx-distribution.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
@@ -39,6 +41,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
     - name: Prepare installation of 32bit packages
       run: sudo dpkg --add-architecture i386 && sudo apt update
     - name: Install cross toolchains and libraries

--- a/.github/workflows/rxtx-distribution.yml
+++ b/.github/workflows/rxtx-distribution.yml
@@ -55,8 +55,10 @@ jobs:
     - uses: actions/download-artifact@v2
       with:
         name: rxtxSerial-binaries-built-on-osx
+    - name: determine version string
+      run: mvn help:evaluate -Dexpression=project.version -q -DforceStdout > project-version.txt
     - name: install osx native library
-      run: cd rxtxSerial-osx-x86_64 && mvn --batch-mode install:install-file -Dfile=target/librxtxSerial-osx-x86_64.jnilib -DgroupId=gnu.io.rxtx -DartifactId=librxtxSerial-osx-x86_64 -Dversion=2.2-stabilize-SNAPSHOT -Dpackaging=jnilib --file pom.xml
+      run: cd rxtxSerial-osx-x86_64 && mvn --batch-mode install:install-file -Dfile=target/librxtxSerial-osx-x86_64.jnilib -DgroupId=gnu.io.rxtx -DartifactId=librxtxSerial-osx-x86_64 -Dversion=$(< ../project-version.txt) -Dpackaging=jnilib --file pom.xml
     - name: Build for all other platforms
       run: mvn --batch-mode -Pwith-linux-x86,with-linux-x86_64,with-linux-armel,with-linux-armhf,with-windows-x86,with-windows-x86_64 package install --file pom.xml
     - name: Bundle rxtx Java and native libs

--- a/.github/workflows/rxtx-distribution.yml
+++ b/.github/workflows/rxtx-distribution.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-osx-binaries:
 
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rxtx-distribution.yml
+++ b/.github/workflows/rxtx-distribution.yml
@@ -4,9 +4,13 @@ name: build rxtx-distribution
 
 on:
   push:
-    branches: [ development ]
+    branches:
+      - '*'
+    tags:
+      - '*'
   pull_request:
-    branches: [ development ]
+    branches:
+      - '*'
 
 jobs:
   build-osx-binaries:
@@ -61,3 +65,10 @@ jobs:
           rxtx-api/target/rxtx-api-*.jar
           rxtxSerial/target/rxtxSerial-*.jar
         if-no-files-found: error
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          rxtx-api/target/rxtx-api-*.jar
+          rxtxSerial/target/rxtxSerial-*.jar

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,10 @@
+<extensions xmlns="https://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="https://maven.apache.org/EXTENSIONS/1.0.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+
+    <extension>
+        <groupId>me.qoomon</groupId>
+        <artifactId>maven-git-versioning-extension</artifactId>
+        <version>7.1.2</version>
+    </extension>
+
+</extensions>

--- a/.mvn/maven-git-versioning-extension.xml
+++ b/.mvn/maven-git-versioning-extension.xml
@@ -1,0 +1,23 @@
+<configuration xmlns="https://github.com/qoomon/maven-git-versioning-extension"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration-7.0.0.xsd">
+
+    <refs>
+        <ref type="branch">
+            <pattern>.+</pattern>
+            <describeTagPattern><![CDATA[v(?<version>.*)]]></describeTagPattern>
+            <version>${describe.tag.version}-${ref}-SNAPSHOT</version>
+        </ref>
+
+        <ref type="tag">
+            <pattern><![CDATA[v(?<version>.*)]]></pattern>
+            <version>${ref.version}</version>
+        </ref>
+    </refs>
+
+    <!-- optional fallback configuration in case of no matching ref configuration-->
+    <rev>
+        <version>${commit}</version>
+    </rev>
+
+</configuration>

--- a/cross-toolchain-wrapper/pom.xml
+++ b/cross-toolchain-wrapper/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>cross-toolchain-wrapper</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>Cross toolchain wrapper</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtx-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>RXTX parent POM</name>
     <url>http://rxtx.qbang.org</url>
     <dependencyManagement>
@@ -12,17 +12,17 @@
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtx-api</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtxSerial-java</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtxSerial</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtxSerial-native</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <scope>compile</scope>
                 <classifier>sources</classifier>
                 <type>zip</type>
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>cross-toolchain-wrapper</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <scope>compile</scope>
                 <classifier>sources</classifier>
                 <type>zip</type>
@@ -49,54 +49,54 @@
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>librxtxSerial-linux-x86</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <type>so</type>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>librxtxSerial-linux-x86_64</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <type>so</type>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>librxtxSerial-linux-armel</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <type>so</type>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>librxtxSerial-linux-armhf</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <type>so</type>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtxSerial-windows-x86</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <type>dll</type>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtxSerial-windows-x86_64</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <type>dll</type>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>librxtxSerial-osx-x86_64</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                 <type>jnilib</type>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtxSerial-bin</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
             </dependency>
             <dependency>
                 <groupId>gnu.io.rxtx</groupId>
                 <artifactId>rxtxSerial-test</artifactId>
-                <version>2.2-stabilize-SNAPSHOT</version>
+                <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rxtx-api/pom.xml
+++ b/rxtx-api/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtx-api</artifactId>
     <packaging>jar</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>RXTX API</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rxtxSerial-bin/pom.xml
+++ b/rxtxSerial-bin/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtxSerial-bin</artifactId>
     <packaging>pom</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>rxtxSerial binaries</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <build>
         <plugins>

--- a/rxtxSerial-java/pom.xml
+++ b/rxtxSerial-java/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtxSerial-java</artifactId>
     <packaging>jar</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>rxtxSerial java</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rxtxSerial-linux-armel/pom.xml
+++ b/rxtxSerial-linux-armel/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>librxtxSerial-linux-armel</artifactId>
     <packaging>so</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>[linux/armel] rxtxSerial</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <profiles>
         <profile>
@@ -90,7 +90,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-native</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
@@ -111,7 +111,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-java</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>jni-headers</classifier>
                                     <overWrite>true</overWrite>
@@ -132,7 +132,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>cross-toolchain-wrapper</artifactId>
-                                    <version>1.0-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>

--- a/rxtxSerial-linux-armhf/pom.xml
+++ b/rxtxSerial-linux-armhf/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>librxtxSerial-linux-armhf</artifactId>
     <packaging>so</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>[linux/armhf] rxtxSerial</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <profiles>
         <profile>
@@ -90,7 +90,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-native</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
@@ -111,7 +111,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-java</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>jni-headers</classifier>
                                     <overWrite>true</overWrite>
@@ -132,7 +132,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>cross-toolchain-wrapper</artifactId>
-                                    <version>1.0-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>

--- a/rxtxSerial-linux-x86/pom.xml
+++ b/rxtxSerial-linux-x86/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>librxtxSerial-linux-x86</artifactId>
     <packaging>so</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>[linux/x86] rxtxSerial</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <profiles>
         <profile>
@@ -157,7 +157,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-native</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
@@ -178,7 +178,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-java</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>jni-headers</classifier>
                                     <overWrite>true</overWrite>

--- a/rxtxSerial-linux-x86_64/pom.xml
+++ b/rxtxSerial-linux-x86_64/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>librxtxSerial-linux-x86_64</artifactId>
     <packaging>so</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>[linux/x86_64] rxtxSerial</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <profiles>
         <profile>
@@ -157,7 +157,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-native</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
@@ -178,7 +178,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-java</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>jni-headers</classifier>
                                     <overWrite>true</overWrite>

--- a/rxtxSerial-native/pom.xml
+++ b/rxtxSerial-native/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtxSerial-native</artifactId>
     <packaging>pom</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>rxtxSerial native</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <build>
         <plugins>

--- a/rxtxSerial-osx-x86_64/pom.xml
+++ b/rxtxSerial-osx-x86_64/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>librxtxSerial-osx-x86_64</artifactId>
     <packaging>jnilib</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>[osx/x86_64] rxtxSerial</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <profiles>
         <profile>
@@ -162,7 +162,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-native</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
@@ -183,7 +183,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-java</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>jni-headers</classifier>
                                     <overWrite>true</overWrite>
@@ -204,7 +204,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>cross-toolchain-wrapper</artifactId>
-                                    <version>1.0-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>

--- a/rxtxSerial-test/pom.xml
+++ b/rxtxSerial-test/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtxSerial-test</artifactId>
     <packaging>jar</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>rxtxSerial integration tests</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rxtxSerial-windows-x86/pom.xml
+++ b/rxtxSerial-windows-x86/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtxSerial-windows-x86</artifactId>
     <packaging>dll</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>[windows/x86] rxtxSerial</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <profiles>
         <profile>
@@ -149,7 +149,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-native</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
@@ -170,7 +170,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-java</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>jni-headers</classifier>
                                     <overWrite>true</overWrite>
@@ -191,7 +191,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>cross-toolchain-wrapper</artifactId>
-                                    <version>1.0-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>

--- a/rxtxSerial-windows-x86_64/pom.xml
+++ b/rxtxSerial-windows-x86_64/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtxSerial-windows-x86_64</artifactId>
     <packaging>dll</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>[windows/x86_64] rxtxSerial</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <profiles>
         <profile>
@@ -149,7 +149,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-native</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>
@@ -170,7 +170,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>rxtxSerial-java</artifactId>
-                                    <version>2.2-stabilize-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>jni-headers</classifier>
                                     <overWrite>true</overWrite>
@@ -191,7 +191,7 @@
                                 <artifactItem>
                                     <groupId>gnu.io.rxtx</groupId>
                                     <artifactId>cross-toolchain-wrapper</artifactId>
-                                    <version>1.0-SNAPSHOT</version>
+                                    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
                                     <type>zip</type>
                                     <classifier>sources</classifier>
                                     <overWrite>true</overWrite>

--- a/rxtxSerial/pom.xml
+++ b/rxtxSerial/pom.xml
@@ -4,13 +4,13 @@
     <groupId>gnu.io.rxtx</groupId>
     <artifactId>rxtxSerial</artifactId>
     <packaging>pom</packaging>
-    <version>2.2-stabilize-SNAPSHOT</version>
+    <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     <name>RXTX default serial driver</name>
     <url>http://rxtx.qbang.org</url>
     <parent>    
         <groupId>gnu.io.rxtx</groupId>
         <artifactId>rxtx-parent</artifactId>
-        <version>2.2-stabilize-SNAPSHOT</version>
+        <version>${project.version}<!-- version calculated by maven-git-versioning-extension based on git tags --></version>
     </parent>
     <build>
         <plugins>


### PR DESCRIPTION
Adds a github actions release mechanism. Pushing a version tag triggers a release build and publishes the result as github release.
The required tag naming pattern is _v.1.2.3_. Release version tags must be git annotated tags, not lightweight tags.