### PR TITLE
Update GitHub Actions dependencies to avoid warnings

### DIFF
--- a/.github/workflows/rxtx-distribution.yml
+++ b/.github/workflows/rxtx-distribution.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: macos-11
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
     - name: Prepare installation of 32bit packages
@@ -48,7 +48,7 @@ jobs:
     - name: Install cross toolchains and libraries
       run: sudo apt install libc6-dev-i386 linux-libc-dev:i386 gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf gcc-mingw-w64-i686 gcc-mingw-w64-x86-64
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'


### PR DESCRIPTION
The build still fails with unrelated issues, but the warnings regarding Node.js are gone.